### PR TITLE
Zaphpa_Callback_Util::getCallback doesn't support inheritance

### DIFF
--- a/zaphpa.lib.php
+++ b/zaphpa.lib.php
@@ -624,13 +624,9 @@ class Zaphpa_Router {
       throw new Zaphpa_InvalidMiddlewareClass("Middleware class: '$className' does not exist or is not a sub-class of Zaphpa_Middleware" );
     }
     
-	if (empty($args)) {
-		$instance = new $className;
-	} else {
-		// convert args array to parameter list
-	    $rc = new ReflectionClass($className);
-		$instance = $rc->newInstanceArgs($args);
-	}
+    // convert args array to parameter list
+    $rc = new ReflectionClass($className);
+    $instance = $rc->newInstanceArgs($args);
 
     self::$middleware[] = $instance;
     return $instance;


### PR DESCRIPTION
If the method you want to route to is an inherited method, the getCallback method will change the class from what you specified to the parent. This is caused by using ReflectionMethod to get the class name and method name after using it to see if the method is static or not. $method->class will return the class the method appears in, not the class you want to call it in.

Example:

``` php
abstract class a {
 function foo() {
  $this->bar();
 }

 abstract function bar();
}

class b inherits a {
 function bar() {
  print 'routed!';
 }
}
```

If I use Zaphpa to route to Array('b', 'foo'), getCallback with instantiate 'a' instead, and the code will fail. 

Submitted pull request ( https://github.com/zaphpa/zaphpa/pull/16 ) with fix.
