### PR TITLE
Adding Support for graddy Url Placeholder

### DIFF
--- a/zaphpa.lib.php
+++ b/zaphpa.lib.php
@@ -608,6 +608,10 @@ class Zaphpa_Router {
   public function addRoute($params) {
     
     if (!empty($params['path'])) {
+      if (strpos($params['path'], '/*')) {
+        $params['path'] = str_replace("/*", "/{args}", $params['path']);
+        $params['handlers'] += array('args' => self::PATTERN_ARGS);
+      }
       
       $template = new Zaphpa_Template($params['path']);
       


### PR DESCRIPTION
This Edit allowed to create url search pattern easy in this style:

Url:
example.de/users/id/all/other/args

Route Path:
/users/{id}/*

Request Params after Mathing Route:
[params] => Array (
    [id] => 1000
    [args] => Array
        (
            [0] => all
            [1] => other
            [2] => args
        )

```
            )
```
