### PR TITLE
allow middleware preroute to prevent main route processing

### DIFF
--- a/zaphpa.lib.php
+++ b/zaphpa.lib.php
@@ -726,7 +726,14 @@ class Zaphpa_Router {
     /* Call preprocessors on each middleware impl */
     foreach (self::$middleware as $m) {
       if ($m->shouldRun('preroute')) {
-        $m->preroute($req,$res);
+        /* the preroute handled the request and doesn't want the main
+         * code to run.. e.g. if the preroute decided the session wasn't
+         * set and wants to issue a 401, or forward using a 302.
+         */
+        if( $m->preroute($req,$res) === FALSE) {
+          return; // nope! don't do anything else.
+        }
+        // continue as usual.
       }
     }
     


### PR DESCRIPTION
the author of a preroute can return FALSE to indicate the preroute decided the main logic line should NOT be executed.  As an example:

The preroute can decide the user isn't logged in, and forward to the login page, issue a 401 or supply an error JSON.  Processing ahead would require enrichment of the request and the controller to be aware of the enrichment.  I'm too lazy to do that, so instead I'd just like the router to suspend operation at that point.
