### PR TITLE
Update zaphpa.lib.php

### DIFF
--- a/zaphpa.lib.php
+++ b/zaphpa.lib.php
@@ -54,7 +54,7 @@ class Zaphpa_Callback_Util {
   
   public static function getCallback($callback, $file = null) {
   
-    if ($file && $callback === null) {
+    if ($file && $callback === NULL) {
       self::loadFile($file);
       return;
     }


### PR DESCRIPTION
ADDED to Zaphpa_Callback_Util->getCallback a test for $callback === null along with a $file to allow for routing to static html pages without throwing the invalidcallback exception.

the add route then is

$router->addRoute(array(
  'path' => '/myfile',
  'get'  => null,
  'file' => 'myfile.html'
));

Also ADDED $callback===null check to Zaphpa_Callback_Util->invokeCallback.
