### PR TITLE
Add support for 429 response codes

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -184,6 +184,7 @@ class Response {
             '415' => 'Unsupported Media Type',
             '416' => 'Requested Range Not Satisfiable',
             '417' => 'Expectation Failed',
+            '429' => 'Too Many Requests',
             '500' => 'Internal Server Error',
             '501' => 'Not Implemented',
             '502' => 'Bad Gateway',


### PR DESCRIPTION
We recently added rate limiting to our NPR One API (hi Irakli!) but were bummed to find that we couldn't return 429 as the HTTP status code because Zaphpa doesn't consider it valid. It's pretty much canonically accepted these days as the status code for rate limiting, so... pretty please? :)
