### PR TITLE
Correccion para php 7.4

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -15,7 +15,7 @@ class Template {
     private $callbacks = array();
 
     public function __construct($path) {
-        if ($path{0} != '/') {
+        if ($path[0] != '/') {
             $path = "/$path";
         }
         $this->template = rtrim($path, '\/');


### PR DESCRIPTION
With the last changes on Php, it seems to be changed the curly braces because it is deprecated.

So we need to change from this:
  ```
public function __construct($path) {
        if ($path{0} != '/') {
            $path = "/$path";
        }
        $this->template = rtrim($path, '\/');
    }
```
to this:
```
  public function __construct($path) {
        if ($path[0] != '/') {
            $path = "/$path";
        }
        $this->template = rtrim($path, '\/');
    }
```
![zaphpa](https://user-images.githubusercontent.com/13791130/81733810-35de1080-9458-11ea-9880-c005b7b59b5a.PNG)


