### PR TITLE
Fix php 8

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Zaphpa;
+use Zaphpa\Exceptions;
 
 /**
  * Generic URI matcher and parser implementation.
@@ -92,7 +93,7 @@ class Template {
                     if ($value) {
                         $matches[$k] = $value;
                     } else {
-                        throw new InvalidURIParameterException('Invalid parameters detected');
+                        throw new Exceptions\InvalidURIParameterException('Invalid parameters detected');
                     }
                 }
 
@@ -131,7 +132,7 @@ class Template {
             }
 
             if ($matched == false) {
-                throw new Exception('Request does not match');
+                throw new \Exception('Request does not match');
             }
 
         }

--- a/src/Template.php
+++ b/src/Template.php
@@ -15,7 +15,7 @@ class Template {
     private $callbacks = array();
 
     public function __construct($path) {
-        if ($path{0} != '/') {
+        if ($path[0] != '/') {
             $path = "/$path";
         }
         $this->template = rtrim($path, '\/');


### PR DESCRIPTION
Fixed deprecated curly braces used for access to string element by index.
Fixed bad namespace on two exception classes.